### PR TITLE
Update config flow to use the WUD URL for container API endpoint

### DIFF
--- a/custom_components/wud_getupdates/config_flow.py
+++ b/custom_components/wud_getupdates/config_flow.py
@@ -15,8 +15,7 @@ class WUDMonitorConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             return self.async_show_form(
                 step_id="user",
                 data_schema=vol.Schema({
-                    vol.Required("host"): str,
-                    vol.Required("port"): int,
+                    vol.Required("container_api_url"): str,
                     vol.Required("instance_name"): str  # Request instance name
                 })
             )
@@ -25,8 +24,7 @@ class WUDMonitorConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         return self.async_create_entry(
             title=user_input["instance_name"],
             data={
-                "host": user_input["host"],
-                "port": user_input["port"],
+                "host": user_input["container_api_url"],
                 "instance_name": user_input["instance_name"]
             }
         )
@@ -48,8 +46,7 @@ class WUDMonitorOptionsFlowHandler(config_entries.OptionsFlow):
             return self.async_show_form(
                 step_id="init",
                 data_schema=vol.Schema({
-                    vol.Optional("host", default=self.config_entry.data.get("host")): str,
-                    vol.Optional("port", default=self.config_entry.data.get("port")): int,
+                    vol.Optional("container_api_url", default=self.config_entry.data.get("container_api_url")): str,
                     vol.Optional("instance_name", default=self.config_entry.data.get("instance_name")): str,
                 })
             )

--- a/custom_components/wud_getupdates/sensor.py
+++ b/custom_components/wud_getupdates/sensor.py
@@ -10,12 +10,11 @@ DOMAIN = "wud_getupdates"
 
 async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry, async_add_entities):
     """Set up the WUD sensor platform."""
-    wud_host = config_entry.data["host"]
-    wud_port = config_entry.data["port"]
+    wud_container_api_url = config_entry.data["container_api_url"]
     instance_name = config_entry.data["instance_name"]  # Get instance name
 
     # Fetch container information from WUD API
-    containers = await get_containers(wud_host, wud_port)
+    containers = await get_containers(wud_container_api_url)
 
     # Create a sensor for each container and assign it to the instance name device
     sensors = []
@@ -24,11 +23,10 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry, asyn
     
     async_add_entities(sensors, True)
 
-async def get_containers(host, port):
+async def get_containers(container_api_url):
     """Fetch containers from the WUD API."""
-    url = f"http://{host}:{port}/api/containers"
     async with aiohttp.ClientSession() as session:
-        async with session.get(url) as response:
+        async with session.get(container_api_url) as response:
             if response.status == 200:
                 return await response.json()
             else:


### PR DESCRIPTION
Updated to use container_api_url rather than host / port.  This should support a wider range of configurations including https and alternate url schemes.

When configuring the integration, you would supply.. 

- container API URL: https://wud.example.com/api/containers
- instance: wud_host

This is related to issue #2 .